### PR TITLE
Use more cores when availabe

### DIFF
--- a/src/main/java/davidsar/gent/stubjars/StubJars.java
+++ b/src/main/java/davidsar/gent/stubjars/StubJars.java
@@ -61,7 +61,7 @@ public class StubJars {
     private static final File BUILD_DIR = new File(SOURCE_DIR, "build");
     private static final File CLASSES_DIR = new File(BUILD_DIR, "classes");
     private static final File SOURCES_LIST_FILE = new File(SOURCE_DIR, "sources.list");
-    private final int numberOfCompilerThreads = 4;
+    private final int numberOfCompilerThreads = Math.min(Runtime.getRuntime().availableProcessors() - 1, 1);
 
 
     private StubJars(@NotNull List<JarClass<?>> clazzes, List<JarFile> classpathJars) {


### PR DESCRIPTION
Fixes #8 
cc @NoahAndrews

Makes use of more cores dynamically. With rough* benchmarking estimates:

Test project runtimes
| Variant | Average Execution Time | Delta % |
| --- | --- | --- |
| Control | 2.00s | N/A |
| `Runtime.getRuntime().availableProcessors()` | 1.55s |  -23% |
| `Runtime.getRuntime().availableProcessors() - 1` | 1.44s |  -28% |

By rough, this means no warmup execution, averaging 3 rounds of execution against the project this code is developed against.
