### PR TITLE
Remove filter for preventing static methods with the same name as a parent member

### DIFF
--- a/src/main/java/davidsar/gent/stubjars/components/JarMethod.java
+++ b/src/main/java/davidsar/gent/stubjars/components/JarMethod.java
@@ -166,11 +166,7 @@ public class JarMethod extends JarModifiers implements CompileableExpression {
             }
         }
 
-        var jarClasses = getParentClazz().allSuperClassesAndInterfaces();
-        long count = jarClasses.values().stream()
-                .filter(x -> x.hasMethod(method))
-                .count();
-        return count == 0 && shouldIncludeMethod();
+        return  shouldIncludeMethod();
     }
 
     private boolean shouldIncludeMethod() {


### PR DESCRIPTION
Resolves an issue where the generated StubJar does not contain a static method if it contains the same name as a parent static method.

- [x] Only manual testing performed